### PR TITLE
X selector tweaks

### DIFF
--- a/components/timeseries.js
+++ b/components/timeseries.js
@@ -72,11 +72,12 @@ const Timeseries = ({
     ) {
       return (
         <Rect
-          x={[mousePosition - 0.02, mousePosition + 0.02]}
+          x={[mousePosition - 0.0001, mousePosition + 0.0001]}
           y={yLimits}
           color='none'
+          vectorEffect='non-scaling-stroke'
           stroke={theme.colors.secondary}
-          strokeWidth={0.3}
+          strokeWidth={1}
           opacity={1}
         />
       )


### PR DESCRIPTION
This PR makes a series of small tweaks to the x selector for time series
- Ensures that x=0 is selectable and x=timeHorizon is not (e.g., can select up through `9y 11m` when timeHorizon=10)
- Uses `non-scaling-stroke` for selector line to ensure consistent width across screen sizes
- Renders selector on top of all `Plot` elements
- Renders label at top of chart (not 100% sure about this one)