### PR TITLE
Tweak colormaps to only use cool and warm

### DIFF
--- a/store/index.js
+++ b/store/index.js
@@ -3,7 +3,7 @@ import { create } from 'zustand'
 export const overviewVariable = {
   key: 'EFFICIENCY',
   colorLimits: [0, 1],
-  colormap: 'water',
+  colormap: 'cool',
   label: 'Efficiency',
   unit: 'mole CO₂ / mole alkalinity',
 }
@@ -51,7 +51,7 @@ export const variables = {
         variable: 'DIC',
         delta: true,
         colorLimits: [0, 0.1],
-        colormap: 'cool',
+        colormap: 'warm',
         label: 'change',
         unit: 'mmol/m³',
       },
@@ -59,7 +59,7 @@ export const variables = {
         variable: 'DIC',
         delta: false,
         colorLimits: [1800, 2300],
-        colormap: 'cool',
+        colormap: 'warm',
         label: 'Total',
         unit: 'mmol/m³',
       },


### PR DESCRIPTION
This PR updates the map to only use `cool` (overview) and `warm` (all region-specific vars) as colormaps in the tool based on the following feedback: 
> Passing along another piece of feedback from Chris Van Arsdale: For the gradients in the interactive tool,
> would it be possible to use one of these color gradients?
> 
> ![image](https://github.com/carbonplan/oae-web/assets/12436887/2148fc38-9abb-4226-a29f-ec230cf3af9c)
> (taken from Matplotlib)
> 
> They're a bit richer than the plain gradient but are still relatively easy to see for folks with colorblindness... 
> 