### PR TITLE
Ensure that tick labels do not run into axis label

### DIFF
--- a/components/timeseries.js
+++ b/components/timeseries.js
@@ -276,7 +276,19 @@ const Timeseries = ({
         <Grid horizontal values={logy && logLabels} />
         <Ticks left values={logy && logLabels} />
         <Ticks bottom values={Array.from({ length: 16 }, (_, i) => i)} />
-        <TickLabels left values={logy && logLabels} format={formatValue} />
+        <TickLabels
+          left
+          values={logy && logLabels}
+          format={(d) => {
+            if (logy) {
+              return formatValue(d, { 0.001: '.0e' })
+            } else if (Math.abs(d) < 0.01) {
+              return <Box sx={{ mr: -2 }}>{d}</Box>
+            } else {
+              return d
+            }
+          }}
+        />
         <TickLabels bottom values={[0, 5, 10, 15]} />
         <AxisLabel units={yLabels.units} sx={{ fontSize: 0 }} left>
           {yLabels.title}


### PR DESCRIPTION
- Special case log labels to only use a single significant digit because log labels are always separated by 10x orders of magnitude
- For very small magnitude (but wide in space) linear tick labels, scoot them to the right to avoid running into axis label

| scale | |
|--------|--------|
| log | ![CleanShot 2024-06-17 at 09 51 05@2x](https://github.com/carbonplan/oae-web/assets/12436887/2ebb55ed-cd0d-4d06-b15e-23515cd98284) |
| linear | ![CleanShot 2024-06-17 at 09 51 40@2x](https://github.com/carbonplan/oae-web/assets/12436887/b981d395-dad1-4800-b61f-37aa0a9611be) | 