### PR TITLE
spacing fixes

### DIFF
--- a/components/about.js
+++ b/components/about.js
@@ -8,7 +8,7 @@ import { CarbonToSea, CWorthy, EDF } from './logos'
 const About = ({ sx }) => {
   return (
     <>
-      <SidebarDivider sx={{ my: 4 }} />
+      <SidebarDivider sx={{ mt: 5, mb: 4 }} />
       <Box sx={sx.heading}>About</Box>
 
       <Box sx={{ fontSize: 1, mb: 3 }}>

--- a/components/overview-chart.js
+++ b/components/overview-chart.js
@@ -147,7 +147,7 @@ const OverviewChart = ({ sx }) => {
 
   return (
     <Box sx={{ mb: 4 }}>
-      <Divider sx={{ mt: 0, mb: 4 }} />
+      <Divider sx={{ mt: 2, mb: 4 }} />
       <Box sx={sx.heading}>Time series</Box>
 
       <Flex sx={{ justifyContent: 'space-between' }}>

--- a/components/region-chart.js
+++ b/components/region-chart.js
@@ -165,10 +165,10 @@ const RegionChart = ({ sx }) => {
   }, [selectedLines])
 
   return (
-    <Box sx={{ mb: 4, height: [0, 0, 390, 390] }}>
+    <Box sx={{ mb: 4, height: [0, 0, 380, 380] }}>
       {index >= 2 && (
         <>
-          <Divider sx={{ mt: 4, mb: 5 }} />
+          <Divider sx={{ mt: 2, mb: 4 }} />
           <Button
             suffix={
               showRegionPicker ? (


### PR DESCRIPTION
Matched up some of the spacing a bit better between sections
* reduced margin below colorbar to match space below charts
* matched spacing of headers and the divider above them across sections

before: 
![image](https://github.com/carbonplan/oae-web/assets/14908734/49527296-2bb5-492e-8446-4b1b4c60f51c)


after: 
![image](https://github.com/carbonplan/oae-web/assets/14908734/9d1dbd60-b495-4ee1-89fd-4783b00c287f)

